### PR TITLE
Update gitignore to skip nested node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+**/node_modules/
 .env
 .DS_Store


### PR DESCRIPTION
## Summary
- ignore `node_modules` directories everywhere

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ed9e62b3c8322a5be34ccf82280f6