### PR TITLE
Add simple React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ This project is a basic TODO API using Node.js and MongoDB.
 
 - `POST /api/users/register` – register a new user.
 - `POST /api/users/login` – log in and receive a token.
+
+## Frontend
+
+This repository also contains a simple React frontend created with Vite.
+
+### Setup
+
+1. `cd frontend`
+2. `npm install`
+3. `npm run dev` – starts the development server at `http://localhost:3000`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "todooptica-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TodoOptica</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,39 @@
+.App {
+  max-width: 400px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+form {
+  margin-bottom: 1.5rem;
+}
+
+input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: red;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import LoginForm from './components/LoginForm';
+import RegisterForm from './components/RegisterForm';
+import './App.css';
+
+function App() {
+  // Estado para el token y el email del usuario
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  const [email, setEmail] = useState(localStorage.getItem('email'));
+
+  // Se ejecuta al iniciar sesión correctamente
+  const handleLogin = (userEmail, authToken) => {
+    setToken(authToken);
+    setEmail(userEmail);
+    localStorage.setItem('token', authToken);
+    localStorage.setItem('email', userEmail);
+  };
+
+  // Cerrar sesión
+  const handleLogout = () => {
+    setToken(null);
+    setEmail(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('email');
+  };
+
+  return (
+    <div className="App">
+      <h1>TodoÓptica</h1>
+      {token ? (
+        <div className="welcome">
+          <p>Bienvenido, {email}!</p>
+          <button onClick={handleLogout}>Cerrar sesión</button>
+        </div>
+      ) : (
+        <div className="forms">
+          <LoginForm onLogin={handleLogin} />
+          <RegisterForm />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+// URL base de la API
+const API_URL = 'http://localhost:5000';
+
+export default function LoginForm({ onLogin }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  // Enviar datos de inicio de sesión al backend
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch(`${API_URL}/api/users/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Error al iniciar sesión');
+        return;
+      }
+      onLogin(email, data.token);
+    } catch (err) {
+      setError('Error de red');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Iniciar sesión</h2>
+      <input
+        type="email"
+        placeholder="Correo electrónico"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Entrar</button>
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+// URL base de la API
+const API_URL = 'http://localhost:5000';
+
+export default function RegisterForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  // Enviar datos de registro al backend
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    try {
+      const res = await fetch(`${API_URL}/api/users/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Error al registrarse');
+        return;
+      }
+      setMessage('Registro exitoso. Ya puedes iniciar sesión.');
+      setName('');
+      setEmail('');
+      setPassword('');
+    } catch (err) {
+      setError('Error de red');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Registro</h2>
+      <input
+        type="text"
+        placeholder="Nombre"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        required
+      />
+      <input
+        type="email"
+        placeholder="Correo electrónico"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Registrarse</button>
+      {message && <p>{message}</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,6 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add `frontend` folder with Vite React app
- include registration and login forms that call the backend
- store auth token and email in `localStorage`
- update README with instructions for running the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683edf13f5dc8322bd1569424ec721f6