### PR TITLE
Add Todo CRUD with frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This project is a basic TODO API using Node.js and MongoDB.
 
 - `POST /api/users/register` – register a new user.
 - `POST /api/users/login` – log in and receive a token.
+- `GET /api/todos` – list todos for a user (pass `userId` as query).
+- `POST /api/todos` – create a todo.
+- `PUT /api/todos/:id` – update a todo.
+- `DELETE /api/todos/:id` – delete a todo.
 
 ## Frontend
 
@@ -34,3 +38,7 @@ This repository also contains a simple React frontend created with Vite.
 1. `cd frontend`
 2. `npm install`
 3. `npm run dev` – starts the development server at `http://localhost:3000`.
+
+After logging in you will see a simple todo list where you can add,
+edit and delete tasks. These actions communicate with the backend
+routes described above.

--- a/backend/app.js
+++ b/backend/app.js
@@ -3,13 +3,14 @@ const cors = require('cors');
 require('dotenv').config();
 
 const userRoutes = require('./routes/userRoutes');
-// Aquí luego importarás más rutas (pedidos, productos, etc.)
+const todoRoutes = require('./routes/todoRoutes');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 app.use('/api/users', userRoutes);
+app.use('/api/todos', todoRoutes);
 
 app.get('/', (req, res) => {
   res.send('API TodoOptica funcionando');

--- a/backend/controllers/todoController.js
+++ b/backend/controllers/todoController.js
@@ -1,0 +1,42 @@
+const Todo = require('../models/Todo');
+
+exports.getTodos = async (req, res) => {
+  try {
+    const todos = await Todo.find({ userId: req.query.userId });
+    res.json(todos);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.createTodo = async (req, res) => {
+  try {
+    const { text, userId } = req.body;
+    const todo = await Todo.create({ text, userId });
+    res.status(201).json(todo);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+exports.updateTodo = async (req, res) => {
+  try {
+    const todo = await Todo.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+    });
+    if (!todo) return res.status(404).json({ error: 'Todo not found' });
+    res.json(todo);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+exports.deleteTodo = async (req, res) => {
+  try {
+    const todo = await Todo.findByIdAndDelete(req.params.id);
+    if (!todo) return res.status(404).json({ error: 'Todo not found' });
+    res.json({ message: 'Todo eliminado' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/backend/models/Todo.js
+++ b/backend/models/Todo.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const todoSchema = new mongoose.Schema({
+  text: { type: String, required: true },
+  completed: { type: Boolean, default: false },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+});
+
+module.exports = mongoose.model('Todo', todoSchema);

--- a/backend/routes/todoRoutes.js
+++ b/backend/routes/todoRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const {
+  getTodos,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} = require('../controllers/todoController');
+
+const router = express.Router();
+
+router.get('/', getTodos);
+router.post('/', createTodo);
+router.put('/:id', updateTodo);
+router.delete('/:id', deleteTodo);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,37 +1,46 @@
 import { useState } from 'react';
 import LoginForm from './components/LoginForm';
 import RegisterForm from './components/RegisterForm';
+import TodoList from './components/TodoList';
 import './App.css';
 
 function App() {
   // Estado para el token y el email del usuario
   const [token, setToken] = useState(localStorage.getItem('token'));
   const [email, setEmail] = useState(localStorage.getItem('email'));
+  const [userId, setUserId] = useState(localStorage.getItem('userId'));
 
   // Se ejecuta al iniciar sesión correctamente
-  const handleLogin = (userEmail, authToken) => {
+  const handleLogin = (userEmail, authToken, id) => {
     setToken(authToken);
     setEmail(userEmail);
+    setUserId(id);
     localStorage.setItem('token', authToken);
     localStorage.setItem('email', userEmail);
+    localStorage.setItem('userId', id);
   };
 
   // Cerrar sesión
   const handleLogout = () => {
     setToken(null);
     setEmail(null);
+    setUserId(null);
     localStorage.removeItem('token');
     localStorage.removeItem('email');
+    localStorage.removeItem('userId');
   };
 
   return (
     <div className="App">
       <h1>TodoÓptica</h1>
       {token ? (
-        <div className="welcome">
-          <p>Bienvenido, {email}!</p>
-          <button onClick={handleLogout}>Cerrar sesión</button>
-        </div>
+        <>
+          <div className="welcome">
+            <p>Bienvenido, {email}!</p>
+            <button onClick={handleLogout}>Cerrar sesión</button>
+          </div>
+          <TodoList />
+        </>
       ) : (
         <div className="forms">
           <LoginForm onLogin={handleLogin} />

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -23,7 +23,7 @@ export default function LoginForm({ onLogin }) {
         setError(data.error || 'Error al iniciar sesión');
         return;
       }
-      onLogin(email, data.token);
+      onLogin(email, data.token, data.userId);
     } catch (err) {
       setError('Error de red');
     }

--- a/frontend/src/components/TodoList.jsx
+++ b/frontend/src/components/TodoList.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+
+const API_URL = 'http://localhost:5000';
+
+export default function TodoList() {
+  const [todos, setTodos] = useState([]);
+  const [text, setText] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/todos?userId=${localStorage.getItem('userId') || ''}`)
+      .then((res) => res.json())
+      .then(setTodos)
+      .catch(() => setError('Error loading todos'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const addTodo = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch(`${API_URL}/api/todos`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, userId: localStorage.getItem('userId') }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error);
+      }
+      const todo = await res.json();
+      setTodos([...todos, todo]);
+      setText('');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const toggleTodo = async (todo) => {
+    try {
+      const res = await fetch(`${API_URL}/api/todos/${todo._id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ completed: !todo.completed }),
+      });
+      const updated = await res.json();
+      setTodos(todos.map((t) => (t._id === updated._id ? updated : t)));
+    } catch {
+      setError('Error updating todo');
+    }
+  };
+
+  const deleteTodo = async (id) => {
+    try {
+      await fetch(`${API_URL}/api/todos/${id}`, { method: 'DELETE' });
+      setTodos(todos.filter((t) => t._id !== id));
+    } catch {
+      setError('Error deleting todo');
+    }
+  };
+
+  if (loading) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>Mis Tareas</h2>
+      <form onSubmit={addTodo}>
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Nueva tarea"
+          required
+        />
+        <button type="submit">Agregar</button>
+      </form>
+      {error && <p className="error">{error}</p>}
+      <ul>
+        {todos.map((t) => (
+          <li key={t._id}>
+            <label>
+              <input
+                type="checkbox"
+                checked={t.completed}
+                onChange={() => toggleTodo(t)}
+              />
+              {t.text}
+            </label>
+            <button onClick={() => deleteTodo(t._id)}>Eliminar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement Todo mongoose model, controller and routes
- expose /api/todos endpoints via backend app
- add TodoList component to frontend and show after login
- extend login to store userId
- update README with new routes and info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68400d3bc92c8322835b5251e3aa7389