### PR TITLE
[codex] Configurar Vercel para servir dist

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/",
+      "destination": "/dist/index.html"
+    },
+    {
+      "source": "/:path*",
+      "destination": "/dist/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Qué cambia

Añade `vercel.json` en la raíz del repositorio para que Vercel sirva la web estática desde `dist/`.

- `/` se reescribe a `/dist/index.html`
- `/:path*` se reescribe a `/dist/:path*`

## Por qué

La producción estaba devolviendo `404: NOT_FOUND` porque el deployment de Vercel estaba sirviendo la raíz del repositorio, mientras que el sitio público quedó publicado dentro de `dist/`.

## Validación

- `vercel.json` parsea como JSON válido
- `npm test`
- Confirmado previamente que `https://todooptica.vercel.app/dist/index.html` responde `200`, mientras `/` devolvía `404`
